### PR TITLE
 Neuer Ersetzungstyp: PHP mit Parametern

### DIFF
--- a/lib/xoutputfilter.php
+++ b/lib/xoutputfilter.php
@@ -468,8 +468,8 @@ class xoutputfilter
                             $paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(?|"([^"]*)"|\'([^\']*)\'|“([^”]*)”)#Uu';
                             $params = [];
                             if (preg_match_all($paramsPattern, $paramsPart, $paramsMatches, PREG_SET_ORDER)) {
-                                #echo '<pre>',print_r($paramsMatches,true),'</pre>';
-                                #die();
+                                echo '<pre>',print_r($paramsMatches,true),'</pre>';
+                                die();
                                 foreach ($paramsMatches as &$pmatch) {
                                     //$params[$pmatch[1]] = $pmatch[3];
                                     $params[$pmatch[1]] = $pmatch[2];

--- a/lib/xoutputfilter.php
+++ b/lib/xoutputfilter.php
@@ -465,7 +465,7 @@ class xoutputfilter
                             // g{-3} matched das selbe Zeichen was zuvor gematcht wurde ' oder "
                             //$paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(["\']|“)(.*)(\\g{-3}|”)#Uu';
                             //$paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(?|(["\'])(.*)\\g{-2}|(“)(.*)”)#Uu';
-                            $paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(?|"([^"]*)"|\'([^\']*)\'|“([^”]*)”)#Uu';
+                            $paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(?|"([^"]*)"|\'([^\']*)\'|“([^”]*)”|\|([^\|]*)\|)#Uu';
                             $params = [];
                             if (preg_match_all($paramsPattern, $paramsPart, $paramsMatches, PREG_SET_ORDER)) {
                                 foreach ($paramsMatches as &$pmatch) {

--- a/lib/xoutputfilter.php
+++ b/lib/xoutputfilter.php
@@ -462,10 +462,16 @@ class xoutputfilter
                         foreach ($matches as &$match) {
                             // Parameter-Teil weiter parsen und $params-Array aufbauen...
                             $paramsPart = trim($match[1][0]);
-                            $paramsPattern = '#([a-zA-Z0-9_:\\-]+)="([^"]*)"#';
+                            // g{-3} matched das selbe Zeichen was zuvor gematcht wurde ' oder "
+                            //$paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(["\']|“)(.*)(\\g{-3}|”)#Uu';
+                            //$paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(?|(["\'])(.*)\\g{-2}|(“)(.*)”)#Uu';
+                            $paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(?|"([^"]*)"|\'([^\']*)\'|“([^”]*)”)#Uu';
                             $params = [];
                             if (preg_match_all($paramsPattern, $paramsPart, $paramsMatches, PREG_SET_ORDER)) {
+                                #echo '<pre>',print_r($paramsMatches,true),'</pre>';
+                                #die();
                                 foreach ($paramsMatches as &$pmatch) {
+                                    //$params[$pmatch[1]] = $pmatch[3];
                                     $params[$pmatch[1]] = $pmatch[2];
                                 }
                             }

--- a/lib/xoutputfilter.php
+++ b/lib/xoutputfilter.php
@@ -465,8 +465,9 @@ class xoutputfilter
                             // g{-3} matched das selbe Zeichen was zuvor gematcht wurde ' oder "
                             //$paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(["\']|“)(.*)(\\g{-3}|”)#Uu';
                             //$paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(?|(["\'])(.*)\\g{-2}|(“)(.*)”)#Uu';
-                            $paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(?|"([^"]*)"|\'([^\']*)\'|“([^”]*)”)#U';
+                            $paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(?|"([^"]*)"|\'([^\']*)\'|“([^”]*)”)#Uu';
                             $params = [];
+                            echo '<pre>',print_r($paramsPart,true),'</pre>';
                             if (preg_match_all($paramsPattern, $paramsPart, $paramsMatches, PREG_SET_ORDER)) {
                                 echo '<pre>',print_r($paramsMatches,true),'</pre>';
                                 die();
@@ -475,13 +476,14 @@ class xoutputfilter
                                     $params[$pmatch[1]] = $pmatch[2];
                                 }
                             }
+                            die('nach dem');
                             
                             // Ersetzung erzeugen, in dem wir den Code mit den $params ausführen...
                             $phprc = xoutputfilter_util::evalphp($replace, $params);
                             if (!$phprc['error']) {
                                 $replacement = $phprc['evaloutput'];
                             } else {
-                                $replacement = 'Fehler beim Ausführen.';
+                                $replacement = $match[0][0]; // kann man sicher feiner machen - marker bleibt.
                             }
                             
                             // content zusammen bauen...

--- a/lib/xoutputfilter.php
+++ b/lib/xoutputfilter.php
@@ -467,16 +467,12 @@ class xoutputfilter
                             //$paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(?|(["\'])(.*)\\g{-2}|(“)(.*)”)#Uu';
                             $paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(?|"([^"]*)"|\'([^\']*)\'|“([^”]*)”)#Uu';
                             $params = [];
-                            echo '<pre>',print_r($paramsPart,true),'</pre>';
                             if (preg_match_all($paramsPattern, $paramsPart, $paramsMatches, PREG_SET_ORDER)) {
-                                echo '<pre>',print_r($paramsMatches,true),'</pre>';
-                                die();
                                 foreach ($paramsMatches as &$pmatch) {
                                     //$params[$pmatch[1]] = $pmatch[3];
                                     $params[$pmatch[1]] = $pmatch[2];
                                 }
                             }
-                            die('nach dem');
                             
                             // Ersetzung erzeugen, in dem wir den Code mit den $params ausführen...
                             $phprc = xoutputfilter_util::evalphp($replace, $params);

--- a/lib/xoutputfilter.php
+++ b/lib/xoutputfilter.php
@@ -465,7 +465,8 @@ class xoutputfilter
                             // g{-3} matched das selbe Zeichen was zuvor gematcht wurde ' oder "
                             //$paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(["\']|“)(.*)(\\g{-3}|”)#Uu';
                             //$paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(?|(["\'])(.*)\\g{-2}|(“)(.*)”)#Uu';
-                            $paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(?|"([^"]*)"|\'([^\']*)\'|“([^”]*)”|\|([^\|]*)\|)#Uu';
+                            // |“([^”]*)”
+                            $paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(?|"([^"]*)"|\'([^\']*)\'|\|([^\|]*)\|)#Uu';
                             $params = [];
                             if (preg_match_all($paramsPattern, $paramsPart, $paramsMatches, PREG_SET_ORDER)) {
                                 foreach ($paramsMatches as &$pmatch) {

--- a/lib/xoutputfilter.php
+++ b/lib/xoutputfilter.php
@@ -453,7 +453,7 @@ class xoutputfilter
                             .preg_quote($marker, $delimiter)
                             .'(.*)'
                             .preg_quote($tagclose, $delimiter)
-                            .$delimiter.'i';
+                            .$delimiter.'Uui';
                     
                     // jedes Vorkommen des Markers finden...
                     if (preg_match_all($pattern, $content, $matches, PREG_SET_ORDER|PREG_OFFSET_CAPTURE)) {

--- a/lib/xoutputfilter.php
+++ b/lib/xoutputfilter.php
@@ -465,7 +465,7 @@ class xoutputfilter
                             // g{-3} matched das selbe Zeichen was zuvor gematcht wurde ' oder "
                             //$paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(["\']|“)(.*)(\\g{-3}|”)#Uu';
                             //$paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(?|(["\'])(.*)\\g{-2}|(“)(.*)”)#Uu';
-                            $paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(?|"([^"]*)"|\'([^\']*)\'|“([^”]*)”)#Uu';
+                            $paramsPattern = '#([a-zA-Z0-9_:\\-]+)=(?|"([^"]*)"|\'([^\']*)\'|“([^”]*)”)#U';
                             $params = [];
                             if (preg_match_all($paramsPattern, $paramsPart, $paramsMatches, PREG_SET_ORDER)) {
                                 echo '<pre>',print_r($paramsMatches,true),'</pre>';

--- a/lib/xoutputfilter_util.php
+++ b/lib/xoutputfilter_util.php
@@ -658,7 +658,7 @@ class xoutputfilter_util
      *
      * @return array
      */
-    public static function evalphp($code)
+    public static function evalphp($code, $params = null)
     {
         $evalresult = array();
         $evalresult['error'] = false;

--- a/plugins/frontend/lang/de_de.lang
+++ b/plugins/frontend/lang/de_de.lang
@@ -34,6 +34,7 @@ xoutputfilter_frontend_insertbefore1 = vor dem Marker einfügen
 xoutputfilter_frontend_insertbefore2 = Marker mit Wert ersetzen
 xoutputfilter_frontend_insertbefore3 = PREG_REPLACE, Regulärer Ausdruck
 xoutputfilter_frontend_insertbefore4 = PHP-Code ausführen
+xoutputfilter_frontend_insertbefore5 = PHP mit Parametern
 
 xoutputfilter_frontend_categories = aktiv bei folgenden Kategorien<br><p class="help-block rex-note">Mehrfachauswahl mit <kbd>STRG</kbd> bzw. <kbd>CMD</kbd></p>
 xoutputfilter_frontend_excludeids = Bei folgenden Seiten-Id's nicht aktiv

--- a/plugins/frontend/lang/en_gb.lang
+++ b/plugins/frontend/lang/en_gb.lang
@@ -34,6 +34,7 @@ xoutputfilter_frontend_insertbefore1 = insert before marker
 xoutputfilter_frontend_insertbefore2 = replace marker
 xoutputfilter_frontend_insertbefore3 = PREG_REPLACE, regular expression
 xoutputfilter_frontend_insertbefore4 = execute PHP code
+xoutputfilter_frontend_insertbefore5 = PHP with parameters
 
 xoutputfilter_frontend_categories = active in the following categories<br><p class="help-block rex-note">select multiple with <kbd>CTRL</kbd> or <kbd>CMD</kbd></p>
 xoutputfilter_frontend_excludeids = not active on the following article Ids

--- a/plugins/frontend/pages/index.php
+++ b/plugins/frontend/pages/index.php
@@ -408,6 +408,7 @@ if ($func == 'add' || $func == 'edit')
     $select->addOption($this->i18n('xoutputfilter_frontend_insertbefore2'), 2);
     $select->addOption($this->i18n('xoutputfilter_frontend_insertbefore3'), 3);
     $select->addOption($this->i18n('xoutputfilter_frontend_insertbefore4'), 4);
+    $select->addOption($this->i18n('xoutputfilter_frontend_insertbefore5'), 5);
     $select->setSize(1);
     $select->setSelected($Values['insertbefore']);
     $n['field'] = $field->get();

--- a/plugins/frontend/php-parameters.md
+++ b/plugins/frontend/php-parameters.md
@@ -7,3 +7,6 @@
  3. als Ersetzung / PHP-Code: `<?php echo date($params['format']); ?>`
  4. Als Marker kann man nun verwenden `[[date format="d.m.Y"]]`
  5. Freuen, wenn das aktuelle Datum richtig formatiert ausgegeben wird.
+
+ 
+__Achtung:__ Manchmal werden die Anführungszeichen automatisch in andere Zeichn umgewandelt und die Parameter werde nnicht erkannt. In solch einem Fall kann auch `param=|wert|` verwendet werden.

--- a/plugins/frontend/php-parameters.md
+++ b/plugins/frontend/php-parameters.md
@@ -1,0 +1,9 @@
+## PHP mit Parameter
+
+### Beispiel
+
+ 1. Wähle _PHP mit Parametern_ als Ersetzungstyp
+ 2. Verwende `date` als Marker (es ist nur ein Wert möglich)
+ 3. als Ersetzung / PHP-Code: `<?php echo date($params['format']); ?>`
+ 4. Als Marker kann man nun verwenden `[[date format="d.m.Y"]]`
+ 5. Freuen, wenn das aktuelle Datum richtig formatiert ausgegeben wird.


### PR DESCRIPTION
Habe das Tool auf Wunsch von @cukabeka erweitert um einen Ersetzungstyp, der im Marker Parameter zulässt. Ersetzung wird dann per PHP-Code realisiert.

Vielleicht ja auch für andere hilfreich?

Siehe plugins/frontend/php-parameters.md
