### PR TITLE
PHP 8.1 fix deprecated

### DIFF
--- a/plugins/abbrev/boot.php
+++ b/plugins/abbrev/boot.php
@@ -8,10 +8,10 @@ if (rex::isBackend() && is_object(rex::getUser())) {
     // Sprachen als Subnavigation einfügen
     rex_extension::register('PAGES_PREPARED', function () {
 
-        $clang_id = str_replace('clang', '', rex_be_controller::getCurrentPagePart(3, ''));
         $page = rex_be_controller::getPageObject('xoutputfilter/abbrev');
 
         if (is_object($page) and rex_clang::count() > 1) {
+            $clang_id = str_replace('clang', '', (string) rex_be_controller::getCurrentPagePart(3, ''));
             foreach (rex_clang::getAll() as $id => $clang) {
                 if (rex::getUser()->getComplexPerm('clang')->hasPerm($id)) {
                     $page->addSubpage((new rex_be_page('clang' . $id, $clang->getName()))

--- a/plugins/backend/pages/index.php
+++ b/plugins/backend/pages/index.php
@@ -4,7 +4,7 @@ function xoutputfilterBackendCheckDup($value, $lang = '')
     $table = rex::getTable('xoutputfilter');
     $oid = rex_request('oid', 'int', '');
 
-    $clang = (int)str_replace('clang', '', rex_be_controller::getCurrentPagePart(3));
+    $clang = (int)str_replace('clang', '', (string) rex_be_controller::getCurrentPagePart(3));
     $clang = rex_clang::exists($clang) ? $clang : rex_clang::getStartId();
     if ($lang <> '') {
         $clang = $lang;

--- a/plugins/frontend/boot.php
+++ b/plugins/frontend/boot.php
@@ -8,10 +8,10 @@ if (rex::isBackend() && is_object(rex::getUser())) {
     // Sprachen als Subnavigation einfügen
     rex_extension::register('PAGES_PREPARED', function () {
 
-        $clang_id = str_replace('clang', '', rex_be_controller::getCurrentPagePart(3, ''));
         $page = rex_be_controller::getPageObject('xoutputfilter/frontend');
 
         if (is_object($page) and rex_clang::count() > 1) {
+            $clang_id = str_replace('clang', '', (string) rex_be_controller::getCurrentPagePart(3, ''));
             foreach (rex_clang::getAll() as $id => $clang) {
                 if (rex::getUser()->getComplexPerm('clang')->hasPerm($id)) {
                     $page->addSubpage((new rex_be_page('clang' . $id, $clang->getName()))


### PR DESCRIPTION
str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated redaxo/src/addons/xoutputfilter/plugins/frontend/boot.php 11

- Erst pageopbject abfragen
- cast rex_be_controller Part 3 als string